### PR TITLE
Fix patch mode logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -257,6 +257,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   source_image_id            = var.source_image_id != null ? var.source_image_id : null
   provision_vm_agent         = true
   patch_mode                 = var.patch_mode != null ? var.patch_mode : null
+  enable_automatic_updates   = var.patch_mode == "Manual" ? false : true
   allow_extension_operations = true
   dedicated_host_id          = var.dedicated_host_id
   license_type               = var.license_type


### PR DESCRIPTION
When patch_mode is set to "Manual" it is mandatory that automatic windows updates are disabled. This does not affect any settings for linux VMs.